### PR TITLE
Changed Regex Semver Version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 cfg-if = "1.0"
 http = "0.2"
 once_cell = "1.7"
-regex = "1.5"
+regex = "1"
 thiserror = "1"
 uuid = "0.8"
 


### PR DESCRIPTION
Now using "1" instead to allow any other 1.x.x version to be compatible. 